### PR TITLE
feat: expose key custody metadata

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -119,6 +119,22 @@ function buildResponse<T extends object>(payload: T): T {
   return payload;
 }
 
+function buildKeyCustody(privateKeyExported: boolean): {
+  mode: "local-dev-server-generated" | "local-dev-export";
+  privateKeyExported: boolean;
+  guidance: string;
+} {
+  return {
+    mode: privateKeyExported
+      ? "local-dev-export"
+      : "local-dev-server-generated",
+    privateKeyExported,
+    guidance: privateKeyExported
+      ? "Demo private-key export is enabled for local development only; never reuse this key in production."
+      : "Private key material was not returned. Use an explicit client-side or managed custody flow for production signing.",
+  };
+}
+
 async function requireMutationAuthorization(
   registry: IdentityRegistry,
   identityId: string,
@@ -329,6 +345,7 @@ export function buildApp(
             ok: true,
             manifest: result.manifest,
             rootKeyId: result.rootKey.id,
+            custody: buildKeyCustody(demoPrivateKeyExport),
             ...(demoPrivateKeyExport
               ? { privateKey: result.rootKey.privateKey }
               : {}),
@@ -461,6 +478,7 @@ export function buildApp(
             manifest: result.manifest,
             agent: result.agent,
             publicKeyId: result.agentKey.id,
+            custody: buildKeyCustody(demoPrivateKeyExport),
             ...(demoPrivateKeyExport
               ? { privateKey: result.agentKey.privateKey }
               : {}),

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -219,6 +219,17 @@ export const verificationOutcomeSchema = {
   additionalProperties: false,
 } as const;
 
+export const keyCustodySchema = {
+  type: "object",
+  required: ["mode", "privateKeyExported", "guidance"],
+  properties: {
+    mode: { enum: ["local-dev-server-generated", "local-dev-export"] },
+    privateKeyExported: { type: "boolean" },
+    guidance: stringSchema,
+  },
+  additionalProperties: false,
+} as const;
+
 export const createIdentityBodySchema = {
   type: "object",
   required: ["id"],
@@ -302,11 +313,12 @@ export const manifestResponseSchema = {
 
 export const createIdentityResponseSchema = {
   type: "object",
-  required: ["ok", "manifest", "rootKeyId"],
+  required: ["ok", "manifest", "rootKeyId", "custody"],
   properties: {
     ok: { const: true },
     manifest: identityManifestSchema,
     rootKeyId: stringSchema,
+    custody: keyCustodySchema,
     privateKey: stringSchema,
   },
   additionalProperties: true,
@@ -314,12 +326,13 @@ export const createIdentityResponseSchema = {
 
 export const registerAgentResponseSchema = {
   type: "object",
-  required: ["ok", "manifest", "agent", "publicKeyId"],
+  required: ["ok", "manifest", "agent", "publicKeyId", "custody"],
   properties: {
     ok: { const: true },
     manifest: identityManifestSchema,
     agent: agentDefinitionSchema,
     publicKeyId: stringSchema,
+    custody: keyCustodySchema,
     privateKey: stringSchema,
   },
   additionalProperties: true,

--- a/apps/api/test/hardening.test.ts
+++ b/apps/api/test/hardening.test.ts
@@ -63,8 +63,23 @@ describe("api hardening", () => {
       });
 
       expect(response.statusCode).toBe(201);
-      const body = response.json() as { ok: true; privateKey?: string };
+      const body = response.json() as {
+        ok: true;
+        privateKey?: string;
+        custody: {
+          mode: string;
+          privateKeyExported: boolean;
+          guidance: string;
+        };
+      };
       expect(body.privateKey).toBeUndefined();
+      expect(body.custody).toMatchObject({
+        mode: "local-dev-server-generated",
+        privateKeyExported: false,
+      });
+      expect(body.custody.guidance).toContain(
+        "Private key material was not returned",
+      );
     } finally {
       await app.close();
       await rm(dir, { recursive: true, force: true });
@@ -83,8 +98,21 @@ describe("api hardening", () => {
       });
 
       expect(response.statusCode).toBe(201);
-      const body = response.json() as { ok: true; privateKey?: string };
+      const body = response.json() as {
+        ok: true;
+        privateKey?: string;
+        custody: {
+          mode: string;
+          privateKeyExported: boolean;
+          guidance: string;
+        };
+      };
       expect(body.privateKey).toBeTypeOf("string");
+      expect(body.custody).toMatchObject({
+        mode: "local-dev-export",
+        privateKeyExported: true,
+      });
+      expect(body.custody.guidance).toContain("local development only");
     } finally {
       await app.close();
       await rm(dir, { recursive: true, force: true });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -35,6 +35,12 @@ export interface MutationSigner {
   signMutation(input: MutationSigningRequest): MutationAuthorization;
 }
 
+export interface KeyCustodyMetadata {
+  mode: "local-dev-server-generated" | "local-dev-export";
+  privateKeyExported: boolean;
+  guidance: string;
+}
+
 export type MutationAuthorizationInput = MutationAuthorization | MutationSigner;
 
 export class HomeApiError extends Error {
@@ -222,6 +228,7 @@ export class HomeClient {
     ok: true;
     manifest: IdentityManifest;
     rootKeyId: string;
+    custody: KeyCustodyMetadata;
     privateKey?: string;
   }> {
     return this.requestJson("/identities", {
@@ -272,6 +279,7 @@ export class HomeClient {
     };
     privateKey?: string;
     publicKeyId: string;
+    custody: KeyCustodyMetadata;
   }> {
     const path = `/identities/${encodeURIComponent(identityId)}/agents`;
     const method = "POST";

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -44,6 +44,26 @@ describe("sdk hardening", () => {
     ).toBe(false);
   });
 
+  it("surfaces custody metadata on identity creation", async () => {
+    const { dir, store } = await createTempStore();
+    const app = buildApp(store);
+
+    try {
+      const address = await app.listen({ port: 0, host: "127.0.0.1" });
+      const client = sdk.createHomeClient(address.replace(/\/$/u, ""));
+
+      const created = await client.createIdentity("custody@home");
+      expect(created.custody).toMatchObject({
+        mode: "local-dev-server-generated",
+        privateKeyExported: false,
+      });
+      expect(created.privateKey).toBeUndefined();
+    } finally {
+      await app.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("throws a structured api error for failed requests", async () => {
     const { dir, store } = await createTempStore();
     const app = buildApp(store);


### PR DESCRIPTION
## Summary
- Adds explicit key custody metadata to identity and agent key creation responses
- Distinguishes local dev server-generated keys from local dev private-key export mode
- Adds SDK typing for custody metadata
- Extends API/SDK tests around private-key non-export and custody guidance

## Why
This is the first implementation slice from the v0.3 production key custody spec. It makes the key boundary explicit in API responses without changing the existing demo/private-key export gate.

## Verification
- `pnpm typecheck`
- `pnpm typecheck:web`
- `pnpm test` — 30 passed
- `pnpm lint`
- `pnpm build:web`

## Tracks
- #11
