### PR TITLE
feat: support external mutation signers

### DIFF
--- a/docs/roadmap/v0.3-build-plan-spec.md
+++ b/docs/roadmap/v0.3-build-plan-spec.md
@@ -103,7 +103,7 @@ Turn the v0.2 local-first developer implementation into a v0.3 alpha that has a 
 ### 4.2 SDK
 
 - Add typed API error classes.
-- Add browser-safe signing helpers.
+- Add browser/external-safe signing helpers that support async signing boundaries without exposing raw private keys to the SDK.
 - Add capability/request verification helpers.
 - Add namespace lifecycle client methods.
 - Add examples for Node and browser runtimes.

--- a/docs/specs/v0.3-production-key-custody.md
+++ b/docs/specs/v0.3-production-key-custody.md
@@ -38,6 +38,10 @@ Move atHome from demo private-key export toward explicit production custody mode
 - Error details must not include private key material, raw signing payload secrets, or replay nonce internals.
 - Key creation responses should return public material, key id, custody mode, and recovery guidance.
 
+## SDK External Signing Boundary
+
+`createExternalMutationSigner(...)` lets clients authorize mutations with an async signing boundary instead of passing raw private keys into the SDK. The SDK constructs the canonical mutation draft, then delegates only the draft signature operation to the caller-provided signer. This supports browser-held keys, passkey-mediated ceremonies, KMS/HSM signing services, and future custody adapters.
+
 ## Recovery Lifecycle
 
 1. Register recovery method.
@@ -62,6 +66,6 @@ Primary risks:
 ## Acceptance Criteria
 
 - Production mode test proves private keys are absent from API responses.
-- SDK exposes custody-mode-aware helpers.
+- SDK exposes custody-mode-aware helpers, including `createExternalMutationSigner(...)` for browser, passkey, KMS, HSM, or other external signing boundaries that should not hand raw private keys to the SDK.
 - Docs explain how to run local demo mode without implying production safety.
 - Key rotation and revocation flows are covered by tests and examples.

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,10 +1,13 @@
 import {
   createMutationAuthorization as protocolCreateMutationAuthorization,
   createSignedRequest as protocolCreateSignedRequest,
+  hashBody,
+  randomNonce,
   serializeMutationAuthorization,
   type CapabilityToken,
   type IdentityManifest,
   type MutationAuthorization,
+  type MutationAuthorizationDraft,
   type ServiceEndpoint,
   type SignedRequest,
   type VerificationOutcome,
@@ -31,8 +34,20 @@ export interface MutationSigningRequest {
   body?: unknown;
 }
 
+export type MaybePromise<T> = T | Promise<T>;
+
 export interface MutationSigner {
-  signMutation(input: MutationSigningRequest): MutationAuthorization;
+  signMutation(
+    input: MutationSigningRequest,
+  ): MaybePromise<MutationAuthorization>;
+}
+
+export interface ExternalMutationSignerInput {
+  identityId: string;
+  keyId?: string;
+  signDraft(draft: MutationAuthorizationDraft): MaybePromise<string>;
+  now?: () => Date;
+  nonce?: () => string;
 }
 
 export interface KeyCustodyMetadata {
@@ -93,16 +108,16 @@ function isMutationSigner(
   return typeof (value as MutationSigner).signMutation === "function";
 }
 
-function mutationAuthorizationFor(
+async function mutationAuthorizationFor(
   authorization: MutationAuthorizationInput | undefined,
   input: MutationSigningRequest,
-): MutationAuthorization | undefined {
+): Promise<MutationAuthorization | undefined> {
   if (!authorization) {
     return undefined;
   }
 
   return isMutationSigner(authorization)
-    ? authorization.signMutation(input)
+    ? await authorization.signMutation(input)
     : authorization;
 }
 
@@ -119,6 +134,30 @@ export function createRootMutationSigner(
         body: request.body,
         privateKey: input.privateKey,
       });
+    },
+  };
+}
+
+export function createExternalMutationSigner(
+  input: ExternalMutationSignerInput,
+): MutationSigner {
+  return {
+    async signMutation(request) {
+      const timestamp = input.now?.() ?? new Date();
+      const draft: MutationAuthorizationDraft = {
+        issuer: input.identityId,
+        signatureKeyId: input.keyId ?? "root",
+        method: request.method.toUpperCase(),
+        path: request.path,
+        bodyHash: hashBody(request.body),
+        timestamp: timestamp.toISOString(),
+        nonce: input.nonce?.() ?? randomNonce(),
+      };
+
+      return {
+        ...draft,
+        signature: await input.signDraft(draft),
+      };
     },
   };
 }
@@ -176,12 +215,15 @@ export class HomeClient {
     return payload as T;
   }
 
-  private withMutationAuthorization(
+  private async withMutationAuthorization(
     init: RequestInit | undefined,
     authorization: MutationAuthorizationInput | undefined,
     input: MutationSigningRequest,
-  ): RequestInit {
-    const signedAuthorization = mutationAuthorizationFor(authorization, input);
+  ): Promise<RequestInit> {
+    const signedAuthorization = await mutationAuthorizationFor(
+      authorization,
+      input,
+    );
     if (!signedAuthorization) {
       return init ?? {};
     }
@@ -237,7 +279,7 @@ export class HomeClient {
     });
   }
 
-  addService(
+  async addService(
     identityId: string,
     service: ServiceEndpoint,
     authorization?: MutationAuthorizationInput,
@@ -245,18 +287,21 @@ export class HomeClient {
     const path = `/identities/${encodeURIComponent(identityId)}/services`;
     const method = "POST";
 
-    return this.requestJson(path, {
-      method,
-      body: stringifyBody(service),
-      ...this.withMutationAuthorization(undefined, authorization, {
-        method,
-        path,
-        body: service,
-      }),
-    });
+    return this.requestJson(
+      path,
+      await this.withMutationAuthorization(
+        { method, body: stringifyBody(service) },
+        authorization,
+        {
+          method,
+          path,
+          body: service,
+        },
+      ),
+    );
   }
 
-  addAgent(
+  async addAgent(
     identityId: string,
     agent: {
       id: string;
@@ -284,18 +329,21 @@ export class HomeClient {
     const path = `/identities/${encodeURIComponent(identityId)}/agents`;
     const method = "POST";
 
-    return this.requestJson(path, {
-      method,
-      body: stringifyBody(agent),
-      ...this.withMutationAuthorization(undefined, authorization, {
-        method,
-        path,
-        body: agent,
-      }),
-    });
+    return this.requestJson(
+      path,
+      await this.withMutationAuthorization(
+        { method, body: stringifyBody(agent) },
+        authorization,
+        {
+          method,
+          path,
+          body: agent,
+        },
+      ),
+    );
   }
 
-  issueCapabilityToken(
+  async issueCapabilityToken(
     identityId: string,
     input: {
       subject: string;
@@ -310,18 +358,21 @@ export class HomeClient {
     const path = `/identities/${encodeURIComponent(identityId)}/capability-tokens`;
     const method = "POST";
 
-    return this.requestJson(path, {
-      method,
-      body: stringifyBody(input),
-      ...this.withMutationAuthorization(undefined, authorization, {
-        method,
-        path,
-        body: input,
-      }),
-    });
+    return this.requestJson(
+      path,
+      await this.withMutationAuthorization(
+        { method, body: stringifyBody(input) },
+        authorization,
+        {
+          method,
+          path,
+          body: input,
+        },
+      ),
+    );
   }
 
-  revokeAgent(
+  async revokeAgent(
     identityId: string,
     agentId: string,
     authorization?: MutationAuthorizationInput,
@@ -337,16 +388,16 @@ export class HomeClient {
     const path = `/identities/${encodeURIComponent(identityId)}/agents/${encodeURIComponent(agentId)}/revoke`;
     const method = "POST";
 
-    return this.requestJson(path, {
-      method,
-      ...this.withMutationAuthorization(undefined, authorization, {
+    return this.requestJson(
+      path,
+      await this.withMutationAuthorization({ method }, authorization, {
         method,
         path,
       }),
-    });
+    );
   }
 
-  revokeCapabilityToken(
+  async revokeCapabilityToken(
     identityId: string,
     tokenId: string,
     authorization?: MutationAuthorizationInput,
@@ -362,16 +413,16 @@ export class HomeClient {
     const path = `/identities/${encodeURIComponent(identityId)}/capability-tokens/${encodeURIComponent(tokenId)}/revoke`;
     const method = "POST";
 
-    return this.requestJson(path, {
-      method,
-      ...this.withMutationAuthorization(undefined, authorization, {
+    return this.requestJson(
+      path,
+      await this.withMutationAuthorization({ method }, authorization, {
         method,
         path,
       }),
-    });
+    );
   }
 
-  revokeKey(
+  async revokeKey(
     identityId: string,
     keyId: string,
     authorization?: MutationAuthorizationInput,
@@ -387,13 +438,13 @@ export class HomeClient {
     const path = `/identities/${encodeURIComponent(identityId)}/keys/${encodeURIComponent(keyId)}/revoke`;
     const method = "POST";
 
-    return this.requestJson(path, {
-      method,
-      ...this.withMutationAuthorization(undefined, authorization, {
+    return this.requestJson(
+      path,
+      await this.withMutationAuthorization({ method }, authorization, {
         method,
         path,
       }),
-    });
+    );
   }
 
   verifyCapability(

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,7 @@
 export {
   HomeApiError,
   HomeClient,
+  createExternalMutationSigner,
   createHomeClient,
   createIdentity,
   createMutationAuthorization,

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -2,7 +2,11 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { IdentityRegistry, LocalJsonStore } from "@home/protocol";
+import {
+  IdentityRegistry,
+  LocalJsonStore,
+  signCanonicalPayload,
+} from "@home/protocol";
 import { buildApp } from "../../../apps/api/src/app.js";
 import * as sdk from "../src/index.js";
 
@@ -21,6 +25,7 @@ describe("sdk hardening", () => {
     expect(helperSurface.createHomeClient).toBeTypeOf("function");
     expect(helperSurface.createSignedRequest).toBeTypeOf("function");
     expect(helperSurface.createRootMutationSigner).toBeTypeOf("function");
+    expect(helperSurface.createExternalMutationSigner).toBeTypeOf("function");
     expect(helperSurface.resolveName).toBeTypeOf("function");
     expect(helperSurface.revokeAgent).toBeTypeOf("function");
     expect(helperSurface.revokeCapabilityToken).toBeTypeOf("function");
@@ -76,6 +81,52 @@ describe("sdk hardening", () => {
       await expect(liveClient.createIdentity("")).rejects.toMatchObject({
         code: "invalid_request",
         message: expect.any(String),
+      });
+    } finally {
+      await app.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("can authorize mutations with an async external signer", async () => {
+    const { dir, store } = await createTempStore();
+    const app = buildApp(store);
+    const registry = new IdentityRegistry(store);
+
+    try {
+      const { rootKey } = await registry.createIdentity("external@home");
+      const address = await app.listen({ port: 0, host: "127.0.0.1" });
+      const client = sdk.createHomeClient(address.replace(/\/$/u, ""));
+      const seenDrafts: unknown[] = [];
+
+      const signer = sdk.createExternalMutationSigner({
+        identityId: "external@home",
+        keyId: rootKey.id,
+        nonce: () => "external-signer-nonce",
+        async signDraft(draft) {
+          seenDrafts.push(draft);
+          return signCanonicalPayload(draft, rootKey.privateKey);
+        },
+      });
+
+      const response = await client.addService(
+        "external@home",
+        {
+          id: "agent@external",
+          type: "agent",
+          endpoint: "https://example.test/agent",
+        },
+        signer,
+      );
+
+      expect(response.ok).toBe(true);
+      expect(seenDrafts).toHaveLength(1);
+      expect(seenDrafts[0]).toMatchObject({
+        issuer: "external@home",
+        signatureKeyId: rootKey.id,
+        method: "POST",
+        path: "/identities/external%40home/services",
+        nonce: "external-signer-nonce",
       });
     } finally {
       await app.close();


### PR DESCRIPTION
## Summary
- Adds `createExternalMutationSigner(...)` for async external signing boundaries
- Allows `MutationSigner.signMutation(...)` to return sync or async authorizations
- Updates mutating SDK methods to await external signers
- Adds integration coverage proving an external signer can authorize registry mutations without giving the SDK raw private keys
- Updates v0.3 custody docs with the external signing boundary

## Why
This advances the v0.3 production key custody spec by enabling browser-held keys, passkey ceremonies, KMS/HSM services, and other custody adapters to sign canonical mutation drafts outside the SDK.

## Verification
- `pnpm typecheck`
- `pnpm typecheck:web`
- `pnpm test` — 31 passed
- `pnpm lint`
- `pnpm build:web`

## Tracks
- #11
