### PR TITLE
feat: Phase C — passkey custody, KMS adapter, identity recovery ceremony

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -126,6 +126,18 @@ const namespaceLifecycleBody = z.object({
   reason: z.string().min(1).optional(),
 });
 
+const recoveryMethodBody = z.object({
+  id: z.string().min(1),
+  type: z.enum(["email", "phone", "key", "passkey", "custom"]),
+  value: z.string().min(1),
+  publicKeyId: z.string().min(1).optional(),
+});
+
+const recoveryCeremonyBody = z.object({
+  recoveryMethodId: z.string().min(1),
+  reason: z.string().min(1).optional(),
+});
+
 function validationError(
   message: string,
   details: Record<string, unknown> = {},
@@ -1287,6 +1299,136 @@ export function buildApp(
         }
 
         const result = await registry.recoverNamespace(params.id, body.reason);
+        const rotatedAt = result.manifest.updatedAt;
+        const rotationPrivateKeyExported =
+          allowExport && !!result.newRootKey.privateKey;
+
+        return reply.code(201).send(
+          buildResponse({
+            ok: true,
+            manifest: result.manifest,
+            rootKeyId: result.newRootKey.id,
+            rotated: {
+              oldRootKeyId: currentManifest.signatureKeyId,
+              newRootKeyId: result.newRootKey.id,
+              rotatedAt,
+            },
+            ...(rotationPrivateKeyExported
+              ? { privateKey: result.newRootKey.privateKey }
+              : {}),
+            custody: buildKeyCustody(rotationPrivateKeyExported),
+          }),
+        );
+      },
+    );
+
+    app.post(
+      "/identities/:id/recovery-methods",
+      {
+        schema: {
+          params: {
+            type: "object",
+            required: ["id"],
+            properties: { id: { type: "string" } },
+            additionalProperties: false,
+          },
+          body: {
+            type: "object",
+            required: ["id", "type", "value"],
+            properties: {
+              id: { type: "string" },
+              type: {
+                type: "string",
+                enum: ["email", "phone", "key", "passkey", "custom"],
+              },
+              value: { type: "string" },
+              publicKeyId: { type: "string" },
+            },
+            additionalProperties: false,
+          },
+          response: {
+            201: manifestResponseSchema,
+            401: errorResponseSchema,
+            403: errorResponseSchema,
+            404: errorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const params = request.params as { id: string };
+        const method = parseBody(recoveryMethodBody, request.body);
+        await requireMutationAuthorization(
+          registry,
+          params.id,
+          request.method,
+          request.url.split("?")[0] ?? request.url,
+          method,
+          request.headers["x-home-authorization"],
+        );
+
+        const existing = await registry.getManifest(params.id);
+        if (!existing) {
+          throw apiError("identity_not_found", "Identity not found", 404);
+        }
+
+        const manifest = await registry.registerRecoveryMethod(
+          params.id,
+          method,
+        );
+        return reply.code(201).send(buildResponse({ ok: true, manifest }));
+      },
+    );
+
+    app.post(
+      "/identities/:id/recover",
+      {
+        schema: {
+          params: {
+            type: "object",
+            required: ["id"],
+            properties: { id: { type: "string" } },
+            additionalProperties: false,
+          },
+          body: {
+            type: "object",
+            required: ["recoveryMethodId"],
+            properties: {
+              recoveryMethodId: { type: "string" },
+              reason: { type: "string" },
+            },
+            additionalProperties: false,
+          },
+          response: {
+            201: rotateRootKeyResponseSchema,
+            401: errorResponseSchema,
+            403: errorResponseSchema,
+            404: errorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const params = request.params as { id: string };
+        const body = parseBody(recoveryCeremonyBody, request.body);
+        requireProductionCustody();
+        await requireMutationAuthorization(
+          registry,
+          params.id,
+          request.method,
+          request.url.split("?")[0] ?? request.url,
+          body,
+          request.headers["x-home-authorization"],
+        );
+
+        const currentManifest = await registry.getManifest(params.id);
+        if (!currentManifest) {
+          throw apiError("identity_not_found", "Identity not found", 404);
+        }
+
+        const result = await registry.executeRecoveryCeremony(
+          params.id,
+          body.recoveryMethodId,
+          body.reason,
+        );
         const rotatedAt = result.manifest.updatedAt;
         const rotationPrivateKeyExported =
           allowExport && !!result.newRootKey.privateKey;

--- a/apps/api/test/hardening.test.ts
+++ b/apps/api/test/hardening.test.ts
@@ -950,4 +950,325 @@ describe("api hardening", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("registers and persists a recovery method", async () => {
+    const { dir, store } = await createTempStore();
+    const { app, custody } = createSharedRegistry(store);
+
+    try {
+      await app.inject({
+        method: "POST",
+        url: "/identities",
+        payload: { id: "alice@atHome" },
+      });
+
+      const privateKey = await exportPrivateKey({
+        custody,
+        identityId: "alice@atHome",
+        keyId: "root",
+      });
+
+      const mutationAuth = createMutationAuthorization({
+        issuer: "alice@atHome",
+        signatureKeyId: "root",
+        method: "POST",
+        path: "/identities/alice@atHome/recovery-methods",
+        body: {
+          id: "backup-key-1",
+          type: "key",
+          value: "ed25519:backup-public-key-placeholder",
+        },
+        privateKey,
+      });
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/identities/alice@atHome/recovery-methods",
+        headers: mutationHeader(mutationAuth),
+        payload: {
+          id: "backup-key-1",
+          type: "key",
+          value: "ed25519:backup-public-key-placeholder",
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json() as {
+        ok: true;
+        manifest: { recovery?: { id: string; type: string }[] };
+      };
+      expect(body.ok).toBe(true);
+      expect(body.manifest.recovery).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "backup-key-1", type: "key" }),
+        ]),
+      );
+    } finally {
+      await app.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("executes identity recovery ceremony and issues new root key", async () => {
+    const { dir, store } = await createTempStore();
+    const app = buildApp(store, { demoPrivateKeyExport: true });
+    const registry = new IdentityRegistry(store);
+
+    try {
+      const { rootKey } = await registry.createIdentity("bob@atHome");
+
+      const registerBody = {
+        id: "passkey-1",
+        type: "passkey",
+        value: "webauthn-credential-id-placeholder",
+      };
+      const registerAuth = createMutationAuthorization({
+        issuer: "bob@atHome",
+        signatureKeyId: rootKey.id,
+        method: "POST",
+        path: "/identities/bob@atHome/recovery-methods",
+        body: registerBody,
+        privateKey: rootKey.privateKey,
+      });
+      await app.inject({
+        method: "POST",
+        url: "/identities/bob@atHome/recovery-methods",
+        headers: mutationHeader(registerAuth),
+        payload: registerBody,
+      });
+
+      const ceremonyBody = {
+        recoveryMethodId: "passkey-1",
+        reason: "lost root key",
+      };
+      const ceremonyAuth = createMutationAuthorization({
+        issuer: "bob@atHome",
+        signatureKeyId: rootKey.id,
+        method: "POST",
+        path: "/identities/bob@atHome/recover",
+        body: ceremonyBody,
+        privateKey: rootKey.privateKey,
+      });
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/identities/bob@atHome/recover",
+        headers: mutationHeader(ceremonyAuth),
+        payload: ceremonyBody,
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json() as {
+        ok: true;
+        rootKeyId: string;
+        rotated: { oldRootKeyId: string; newRootKeyId: string };
+        custody: { mode: string; privateKeyExported: boolean };
+        privateKey?: string;
+      };
+      expect(body.ok).toBe(true);
+      expect(body.rotated.oldRootKeyId).not.toBe(body.rotated.newRootKeyId);
+      expect(body.custody.privateKeyExported).toBe(true);
+      expect(body.privateKey).toBeDefined();
+    } finally {
+      await app.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("recovery ceremony blocks in production mode", async () => {
+    const { dir, store } = await createTempStore();
+    const { app, custody } = createSharedRegistry(store);
+    const previousNodeEnv = process.env["NODE_ENV"];
+
+    try {
+      await app.inject({
+        method: "POST",
+        url: "/identities",
+        payload: { id: "carol@atHome" },
+      });
+
+      const privateKey = await exportPrivateKey({
+        custody,
+        identityId: "carol@atHome",
+        keyId: "root",
+      });
+
+      const registerBody = {
+        id: "backup-passkey",
+        type: "passkey",
+        value: "webauthn-credential-placeholder",
+      };
+      const registerAuth = createMutationAuthorization({
+        issuer: "carol@atHome",
+        signatureKeyId: "root",
+        method: "POST",
+        path: "/identities/carol@atHome/recovery-methods",
+        body: registerBody,
+        privateKey,
+      });
+      await app.inject({
+        method: "POST",
+        url: "/identities/carol@atHome/recovery-methods",
+        headers: mutationHeader(registerAuth),
+        payload: registerBody,
+      });
+
+      process.env["NODE_ENV"] = "production";
+
+      const ceremonyBody = {
+        recoveryMethodId: "backup-passkey",
+        reason: "testing production hardening",
+      };
+      const ceremonyAuth = createMutationAuthorization({
+        issuer: "carol@atHome",
+        signatureKeyId: "root",
+        method: "POST",
+        path: "/identities/carol@atHome/recover",
+        body: ceremonyBody,
+        privateKey,
+      });
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/identities/carol@atHome/recover",
+        headers: mutationHeader(ceremonyAuth),
+        payload: ceremonyBody,
+      });
+
+      // requireProductionCustody() blocks this route in production until a
+      // production-grade custody provider (passkey/KMS/HSM) is wired up.
+      expect(res.statusCode).toBe(403);
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete process.env["NODE_ENV"];
+      } else {
+        process.env["NODE_ENV"] = previousNodeEnv;
+      }
+      await app.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("recovery ceremony omits private key when demo export is not enabled", async () => {
+    const { dir, store } = await createTempStore();
+    const app = buildApp(store);
+    const registry = new IdentityRegistry(store);
+
+    try {
+      const { rootKey } = await registry.createIdentity("eve@atHome");
+
+      const registerBody = {
+        id: "backup-key",
+        type: "key",
+        value: "ed25519:backup-placeholder",
+      };
+      await app.inject({
+        method: "POST",
+        url: "/identities/eve@atHome/recovery-methods",
+        headers: mutationHeader(
+          createMutationAuthorization({
+            issuer: "eve@atHome",
+            signatureKeyId: rootKey.id,
+            method: "POST",
+            path: "/identities/eve@atHome/recovery-methods",
+            body: registerBody,
+            privateKey: rootKey.privateKey,
+          }),
+        ),
+        payload: registerBody,
+      });
+
+      const ceremonyBody = {
+        recoveryMethodId: "backup-key",
+        reason: "testing default key omission",
+      };
+      const res = await app.inject({
+        method: "POST",
+        url: "/identities/eve@atHome/recover",
+        headers: mutationHeader(
+          createMutationAuthorization({
+            issuer: "eve@atHome",
+            signatureKeyId: rootKey.id,
+            method: "POST",
+            path: "/identities/eve@atHome/recover",
+            body: ceremonyBody,
+            privateKey: rootKey.privateKey,
+          }),
+        ),
+        payload: ceremonyBody,
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json() as {
+        ok: true;
+        custody: { mode: string; privateKeyExported: boolean };
+        privateKey?: string;
+      };
+      expect(body.ok).toBe(true);
+      expect(body.privateKey).toBeUndefined();
+      expect(body.custody.privateKeyExported).toBe(false);
+    } finally {
+      await app.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects duplicate recovery method registration", async () => {
+    const { dir, store } = await createTempStore();
+    const { app, custody } = createSharedRegistry(store);
+
+    try {
+      await app.inject({
+        method: "POST",
+        url: "/identities",
+        payload: { id: "dave@atHome" },
+      });
+
+      const privateKey = await exportPrivateKey({
+        custody,
+        identityId: "dave@atHome",
+        keyId: "root",
+      });
+
+      const methodBody = {
+        id: "method-1",
+        type: "email",
+        value: "dave@example.com",
+      };
+      const firstAuth = createMutationAuthorization({
+        issuer: "dave@atHome",
+        signatureKeyId: "root",
+        method: "POST",
+        path: "/identities/dave@atHome/recovery-methods",
+        body: methodBody,
+        privateKey,
+      });
+      await app.inject({
+        method: "POST",
+        url: "/identities/dave@atHome/recovery-methods",
+        headers: mutationHeader(firstAuth),
+        payload: methodBody,
+      });
+
+      const secondAuth = createMutationAuthorization({
+        issuer: "dave@atHome",
+        signatureKeyId: "root",
+        method: "POST",
+        path: "/identities/dave@atHome/recovery-methods",
+        body: methodBody,
+        privateKey,
+      });
+      const duplicate = await app.inject({
+        method: "POST",
+        url: "/identities/dave@atHome/recovery-methods",
+        headers: mutationHeader(secondAuth),
+        payload: methodBody,
+      });
+
+      expect(duplicate.statusCode).toBeGreaterThanOrEqual(400);
+    } finally {
+      await app.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/docs/specs/v0.3-production-key-custody.md
+++ b/docs/specs/v0.3-production-key-custody.md
@@ -38,9 +38,40 @@ Move from demo private-key export toward explicit production custody modes where
 - Error details must not include private key material, raw signing payload secrets, or replay nonce internals.
 - Key creation responses should return public material, key id, custody mode, and recovery guidance.
 
-## SDK External Signing Boundary
+## SDK Signing Helpers
 
-`createExternalMutationSigner(...)` lets clients authorize mutations with an async signing boundary instead of passing raw private keys into the SDK. The SDK constructs the canonical mutation draft, then delegates only the draft signature operation to the caller-provided signer. This supports browser-held keys, passkey-mediated ceremonies, KMS/HSM signing services, and future custody adapters.
+| Helper                          | Runtime            | Private key exposure                 |
+| ------------------------------- | ------------------ | ------------------------------------ |
+| `createInMemoryMutationSigner`  | Node.js            | Raw hex key in memory                |
+| `createWebCryptoMutationSigner` | Browser / Node 20+ | `CryptoKey` — non-extractable        |
+| `createPasskeyMutationSigner`   | Browser            | None — authenticator holds key       |
+| `createExternalMutationSigner`  | Any                | Caller-supplied `signDraft` callback |
+
+`createExternalMutationSigner(...)` lets clients authorize mutations with an async signing boundary instead of passing raw private keys into the SDK. The SDK constructs the canonical mutation draft, then delegates only the signature step to the caller-provided signer. This supports browser-held keys, passkey-mediated ceremonies, KMS/HSM signing services, and future custody adapters.
+
+`createPasskeyMutationSigner(...)` builds on `createExternalMutationSigner` with a WebAuthn-specific interface: the caller provides a `requestAssertion` callback that calls `navigator.credentials.get` with the mutation draft as the challenge and returns the raw assertion signature bytes. The authenticator signs; the signature bytes are base64-encoded into the `MutationAuthorization` envelope. See `examples/browser-passkey-signer.ts`.
+
+## HSM/KMS Adapter Contract
+
+`HsmKeyCustodyProvider` (defined in `packages/protocol/src/custody.ts`) is the interface for hardware or cloud-KMS-backed key management:
+
+```typescript
+interface HsmKeyCustodyProvider {
+  readonly providerName: string;
+  provisionKey(input): Promise<HsmProvisionKeyResult>;
+  sign(input): Promise<string>; // signing only — no raw key access
+  rotateKey(input): Promise<RotateKeyResult>;
+  describeKey(identityId, keyId): Promise<HsmProvisionKeyResult | null>;
+  // exportPrivateKey is intentionally absent
+}
+```
+
+`KmsKeyCustodyAdapter` is a concrete skeleton that wires three caller-supplied callbacks (`kmsProvision`, `kmsSign`, `kmsDescribe`) to the interface. Wire these to your KMS SDK:
+
+- **AWS KMS**: `CreateKey` + `GetPublicKey` for provision; `Sign` (Ed25519) for sign; `DescribeKey` for describe.
+- **GCP Cloud KMS**: `CreateCryptoKey` + `GetPublicKey` for provision; `AsymmetricSign` for sign; `GetCryptoKey` for describe.
+
+Raw private key material never leaves the HSM. The `CustodyKeyRecord` persisted to the store contains `provider`, `keyArn`/`resourceName`, and `exportable: false`.
 
 ## Root Key Rotation
 
@@ -67,9 +98,29 @@ Primary risks:
 - malicious namespace transfer
 - user lockout after root-key loss
 
+## Recovery Ceremony API
+
+```
+POST /identities/:id/recovery-methods
+  Body: { id, type, value, publicKeyId? }
+  Auth: X-Home-Authorization (root key)
+  → 201: { ok, manifest }        // manifest now contains the registered method
+
+POST /identities/:id/recover
+  Body: { recoveryMethodId, reason? }
+  Auth: X-Home-Authorization (root key or recovery key)
+  → 201: { ok, manifest, rootKeyId, rotated, custody }
+```
+
+The `executeRecoveryCeremony` registry method validates that the referenced `recoveryMethodId` exists in the manifest, then calls `rotateRootKey` to issue a new root key and record an `identity.recovered` event. The new private key is returned only when `ATHOME_DEMO_PRIVATE_KEY_EXPORT=true` outside production.
+
 ## Acceptance Criteria
 
-- Production mode test proves private keys are absent from API responses.
-- SDK exposes custody-mode-aware helpers, including `createExternalMutationSigner(...)` for browser, passkey, KMS, HSM, or other external signing boundaries that should not hand raw private keys to the SDK.
+- `PasskeyKeyCustodyProvider` implemented in `packages/protocol/src/custody.ts` — no `exportPrivateKey` support.
+- `createPasskeyMutationSigner` exported from `@athome/sdk` — delegates signing to a `requestAssertion` callback.
+- `HsmKeyCustodyProvider` interface and `KmsKeyCustodyAdapter` skeleton in `packages/protocol/src/custody.ts`.
+- `POST /identities/:id/recovery-methods` and `POST /identities/:id/recover` routes implemented and covered in `hardening.test.ts`.
+- Production mode test proves private keys are absent from recovery ceremony responses.
+- SDK exposes custody-mode-aware helpers for browser, passkey, KMS/HSM signing boundaries.
 - Docs explain how to run local demo mode without implying production safety.
 - Key rotation and revocation flows are covered by tests and examples.

--- a/examples/browser-passkey-signer.ts
+++ b/examples/browser-passkey-signer.ts
@@ -1,0 +1,127 @@
+/**
+ * Browser passkey signer demo.
+ *
+ * Demonstrates using a WebAuthn passkey credential to sign atHome mutation
+ * authorization headers in the browser — no raw private key is ever exposed
+ * to the SDK or the page.
+ *
+ * Prerequisites:
+ *   - The user has a registered WebAuthn credential whose public key was
+ *     provisioned into their atHome identity manifest.
+ *   - The page is served over HTTPS (WebAuthn requirement).
+ *   - `navigator.credentials` is available.
+ */
+
+import {
+  createPasskeyMutationSigner,
+  createAtHomeClient,
+  type MutationAuthorization,
+  type ServiceEndpoint,
+} from "@athome/sdk";
+
+export interface PasskeySignerOptions {
+  apiBaseUrl: string;
+  identityId: string;
+  rootKeyId: string;
+  credentialId: string;
+}
+
+/**
+ * Calls `navigator.credentials.get` with the mutation draft as the WebAuthn
+ * challenge and returns the raw assertion signature bytes.
+ */
+async function webAuthnAssertion(input: {
+  identityId: string;
+  keyId: string;
+  challenge: Uint8Array;
+}): Promise<{ signature: Uint8Array }> {
+  const credential = (await navigator.credentials.get({
+    publicKey: {
+      challenge: input.challenge.buffer as ArrayBuffer,
+      rpId: window.location.hostname,
+      userVerification: "required",
+      timeout: 60_000,
+    },
+  })) as PublicKeyCredential | null;
+
+  if (!credential) {
+    throw new Error("WebAuthn assertion cancelled or unavailable");
+  }
+
+  const response = credential.response as AuthenticatorAssertionResponse;
+  return { signature: new Uint8Array(response.signature) };
+}
+
+/**
+ * Serializes a MutationAuthorization as a base64url-encoded JSON string,
+ * matching the server's expected `X-Home-Authorization` header format.
+ */
+function serializeAuth(auth: MutationAuthorization): string {
+  return btoa(JSON.stringify(auth))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Registers a service using a passkey-backed mutation signer.
+ * The raw signing key never leaves the authenticator.
+ */
+export async function registerServiceWithPasskey(
+  options: PasskeySignerOptions,
+  service: ServiceEndpoint,
+): Promise<void> {
+  const client = createAtHomeClient(options.apiBaseUrl);
+
+  const signer = createPasskeyMutationSigner({
+    identityId: options.identityId,
+    keyId: options.rootKeyId,
+    credentialId: options.credentialId,
+    requestAssertion: webAuthnAssertion,
+  });
+
+  await client.addService(options.identityId, service, signer);
+}
+
+/**
+ * Registers a recovery method (e.g. a backup passkey credential) using the
+ * primary passkey signer. Uses the raw fetch path since AtHomeClient does not
+ * yet expose typed recovery-method helpers.
+ */
+export async function registerRecoveryMethodWithPasskey(
+  options: PasskeySignerOptions,
+  recoveryMethod: { id: string; type: "passkey" | "key"; value: string },
+): Promise<void> {
+  const signer = createPasskeyMutationSigner({
+    identityId: options.identityId,
+    keyId: options.rootKeyId,
+    credentialId: options.credentialId,
+    requestAssertion: webAuthnAssertion,
+  });
+
+  const path = `/identities/${encodeURIComponent(options.identityId)}/recovery-methods`;
+  const auth = await signer.signMutation({
+    method: "POST",
+    path,
+    body: recoveryMethod,
+  });
+
+  const res = await fetch(`${options.apiBaseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-home-authorization": serializeAuth(auth),
+    },
+    body: JSON.stringify(recoveryMethod),
+  });
+
+  if (!res.ok) {
+    const err = (await res.json().catch(() => null)) as {
+      error?: { message?: string };
+    } | null;
+    throw new Error(
+      err?.error?.message ??
+        `Recovery method registration failed: HTTP ${res.status}`,
+    );
+  }
+}

--- a/packages/protocol/src/custody.ts
+++ b/packages/protocol/src/custody.ts
@@ -224,3 +224,239 @@ export function createMemoryKeyCustodyProvider(
 ): KeyCustodyProvider {
   return createLocalDevKeyCustody(options);
 }
+
+// ---------------------------------------------------------------------------
+// PasskeyKeyCustodyProvider
+// ---------------------------------------------------------------------------
+// Signing is delegated to a caller-provided WebAuthn assertion callback.
+// Raw private keys never exist in this provider — no exportPrivateKey support.
+
+export interface PasskeyAssertionInput {
+  identityId: string;
+  keyId: string;
+  challenge: Uint8Array;
+}
+
+export interface PasskeyAssertion {
+  signature: Uint8Array;
+  authenticatorData: Uint8Array;
+  clientDataJSON: Uint8Array;
+}
+
+export interface PasskeyKeyCustodyProviderOptions {
+  identityId: string;
+  credentialId: string;
+  publicKey: string;
+  requestAssertion(input: PasskeyAssertionInput): Promise<PasskeyAssertion>;
+  recordStore?: KeyCustodyRecordStore | undefined;
+}
+
+export class PasskeyKeyCustodyProvider implements KeyCustodyProvider {
+  private readonly options: PasskeyKeyCustodyProviderOptions;
+
+  constructor(options: PasskeyKeyCustodyProviderOptions) {
+    this.options = options;
+  }
+
+  async provisionKey(input: ProvisionKeyInput): Promise<PublicKey> {
+    const now = new Date().toISOString();
+    const record: CustodyKeyRecord = {
+      identityId: input.identityId,
+      keyId: input.keyId,
+      provider: "passkey",
+      publicKeyId: this.options.credentialId,
+      purpose: input.purpose,
+      status: "active",
+      createdAt: now,
+      updatedAt: now,
+      exportable: false,
+      metadata: { credentialId: this.options.credentialId },
+    };
+
+    await this.options.recordStore?.writeCustodyKeyRecord(record);
+
+    return {
+      id: input.keyId,
+      type: "ed25519",
+      publicKey: this.options.publicKey,
+      purpose: input.purpose,
+      status: "active",
+      createdAt: now,
+    };
+  }
+
+  async sign(input: SignInput): Promise<string> {
+    const canonical = JSON.stringify(input.payload);
+    const challenge = new TextEncoder().encode(canonical);
+
+    const assertion = await this.options.requestAssertion({
+      identityId: input.identityId,
+      keyId: input.keyId,
+      challenge,
+    });
+
+    // Return the assertion signature as base64 for use in mutation auth headers.
+    // Consumers must verify the WebAuthn assertion envelope separately.
+    return btoa(String.fromCharCode(...assertion.signature));
+  }
+
+  async rotateKey(input: RotateKeyInput): Promise<RotateKeyResult> {
+    // Passkey rotation is managed by the passkey provider (authenticator).
+    // The caller should provision a new credential and call provisionKey on the new provider.
+    throw new Error(
+      `Passkey key rotation for ${input.identityId}:${input.keyId} must be performed by re-enrolling a new passkey credential`,
+    );
+  }
+
+  async exportPrivateKey(_input: ExportPrivateKeyInput): Promise<string> {
+    throw new Error("PasskeyKeyCustodyProvider does not export private keys");
+  }
+}
+
+export function createPasskeyKeyCustodyProvider(
+  options: PasskeyKeyCustodyProviderOptions,
+): KeyCustodyProvider {
+  return new PasskeyKeyCustodyProvider(options);
+}
+
+// ---------------------------------------------------------------------------
+// HsmKeyCustodyProvider interface + KMS skeleton
+// ---------------------------------------------------------------------------
+// Raw private keys are never exported from HSM-backed providers.
+// Implementors wire `provisionKey` and `sign` to their KMS/HSM SDK calls.
+
+export interface HsmProvisionKeyResult {
+  keyId: string;
+  publicKey: string;
+  keyArn?: string | undefined;
+  resourceName?: string | undefined;
+}
+
+export interface HsmKeyCustodyProvider {
+  readonly providerName: string;
+  provisionKey(input: ProvisionKeyInput): Promise<HsmProvisionKeyResult>;
+  sign(input: SignInput): Promise<string>;
+  rotateKey(input: RotateKeyInput): Promise<RotateKeyResult>;
+  // exportPrivateKey is intentionally absent — HSM keys never leave the HSM.
+  describeKey(
+    identityId: string,
+    keyId: string,
+  ): Promise<HsmProvisionKeyResult | null>;
+}
+
+/**
+ * Reference skeleton for AWS KMS or GCP Cloud KMS.
+ * Wire `kmsSign` to your KMS SDK (e.g. `@aws-sdk/client-kms` SignCommand).
+ * Wire `kmsProvision` to CreateKey / GetPublicKey.
+ * Wire `kmsDescribe` to DescribeKey / GetKeyMetadata.
+ */
+export interface KmsAdapterOptions {
+  providerName: string;
+  kmsProvision(input: {
+    identityId: string;
+    keyId: string;
+    purpose: KeyPurpose;
+  }): Promise<HsmProvisionKeyResult>;
+  kmsSign(input: {
+    identityId: string;
+    keyId: string;
+    payload: unknown;
+  }): Promise<string>;
+  kmsDescribe(
+    identityId: string,
+    keyId: string,
+  ): Promise<HsmProvisionKeyResult | null>;
+  recordStore?: KeyCustodyRecordStore | undefined;
+}
+
+export class KmsKeyCustodyAdapter implements HsmKeyCustodyProvider {
+  readonly providerName: string;
+  private readonly options: KmsAdapterOptions;
+
+  constructor(options: KmsAdapterOptions) {
+    this.providerName = options.providerName;
+    this.options = options;
+  }
+
+  async provisionKey(input: ProvisionKeyInput): Promise<HsmProvisionKeyResult> {
+    const result = await this.options.kmsProvision(input);
+    const now = new Date().toISOString();
+    await this.options.recordStore?.writeCustodyKeyRecord({
+      identityId: input.identityId,
+      keyId: input.keyId,
+      provider: this.providerName,
+      publicKeyId: result.keyId,
+      purpose: input.purpose,
+      status: "active",
+      createdAt: now,
+      updatedAt: now,
+      exportable: false,
+      metadata: {
+        keyArn: result.keyArn,
+        resourceName: result.resourceName,
+      },
+    });
+    return result;
+  }
+
+  async sign(input: SignInput): Promise<string> {
+    return this.options.kmsSign(input);
+  }
+
+  async rotateKey(input: RotateKeyInput): Promise<RotateKeyResult> {
+    const previous = await this.describeKey(input.identityId, input.keyId);
+    if (!previous) {
+      throw new Error(`Unknown KMS key: ${input.identityId}:${input.keyId}`);
+    }
+    const now = new Date().toISOString();
+    await this.options.recordStore?.writeCustodyKeyRecord({
+      identityId: input.identityId,
+      keyId: input.keyId,
+      provider: this.providerName,
+      publicKeyId: previous.keyId,
+      purpose: "root",
+      status: "deprecated",
+      createdAt: now,
+      updatedAt: now,
+      deactivatedAt: now,
+      exportable: false,
+    });
+    const next = await this.provisionKey({
+      identityId: input.identityId,
+      keyId: input.newKeyId,
+      purpose: "root",
+    });
+    return {
+      previous: {
+        id: input.keyId,
+        type: "ed25519",
+        publicKey: previous.publicKey,
+        purpose: "root",
+        status: "deprecated",
+        createdAt: now,
+        deactivatedAt: now,
+      },
+      current: {
+        id: input.newKeyId,
+        type: "ed25519",
+        publicKey: next.publicKey,
+        purpose: "root",
+        status: "active",
+        createdAt: now,
+      },
+    };
+  }
+
+  async describeKey(
+    identityId: string,
+    keyId: string,
+  ): Promise<HsmProvisionKeyResult | null> {
+    return this.options.kmsDescribe(identityId, keyId);
+  }
+}
+
+export function createKmsKeyCustodyAdapter(
+  options: KmsAdapterOptions,
+): KmsKeyCustodyAdapter {
+  return new KmsKeyCustodyAdapter(options);
+}

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -18,7 +18,9 @@ export type RegistryEventType =
   | "namespace.suspended"
   | "namespace.restored"
   | "namespace.transferred"
-  | "namespace.recovered";
+  | "namespace.recovered"
+  | "recovery.method.registered"
+  | "identity.recovered";
 
 export interface RegistryEventDraft {
   id: string;

--- a/packages/protocol/src/registry.ts
+++ b/packages/protocol/src/registry.ts
@@ -4,6 +4,7 @@ import type {
   IdentityManifest,
   PrivateKeyMaterial,
   PublicKey,
+  RecoveryMethod,
   RevocationRecord,
   ServiceEndpoint,
   VerificationOutcome,
@@ -822,6 +823,70 @@ export class IdentityRegistry {
       manifest: resigned,
       newRootKey: rotated.newRootKey,
     };
+  }
+
+  async registerRecoveryMethod(
+    identityId: string,
+    method: RecoveryMethod,
+  ): Promise<IdentityManifest> {
+    const current = await this.requireManifest(identityId);
+    const existing = current.recovery ?? [];
+    if (existing.some((m) => m.id === method.id)) {
+      throw new Error(
+        `Recovery method ${method.id} already registered for ${identityId}`,
+      );
+    }
+
+    const updated: IdentityManifest = {
+      ...current,
+      recovery: [...existing, method],
+      updatedAt: new Date().toISOString(),
+    };
+    const resigned = await this.resign(identityId, updated);
+    await this.backend.writeManifest(resigned);
+    await this.recordEvent(
+      identityId,
+      "recovery.method.registered",
+      identityId,
+      resigned.signatureKeyId,
+      { methodId: method.id, methodType: method.type },
+    );
+    return resigned;
+  }
+
+  async executeRecoveryCeremony(
+    identityId: string,
+    recoveryMethodId: string,
+    reason = "identity recovery ceremony",
+  ): Promise<{ manifest: IdentityManifest; newRootKey: PrivateKeyMaterial }> {
+    const current = await this.requireManifest(identityId);
+    const method = (current.recovery ?? []).find(
+      (m) => m.id === recoveryMethodId,
+    );
+    if (!method) {
+      throw new Error(
+        `Recovery method ${recoveryMethodId} not found for ${identityId}`,
+      );
+    }
+
+    const rotated = await this.rotateRootKey(identityId);
+    const resigned = await this.resign(identityId, rotated.manifest);
+    await this.backend.writeManifest(resigned);
+    await this.recordEvent(
+      identityId,
+      "identity.recovered",
+      identityId,
+      resigned.signatureKeyId,
+      {
+        reason,
+        recoveryMethodId,
+        recoveryMethodType: method.type,
+        oldRootKeyId: current.signatureKeyId,
+        newRootKeyId: rotated.newRootKey.id,
+      },
+    );
+
+    return { manifest: resigned, newRootKey: rotated.newRootKey };
   }
 
   private async requireManifest(identityId: string): Promise<IdentityManifest> {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -96,6 +96,23 @@ export interface KeyCustodyMetadata {
   guidance: string;
 }
 
+export interface PasskeyMutationSignerInput {
+  identityId: string;
+  keyId?: string;
+  credentialId: string;
+  /**
+   * Call navigator.credentials.get (or equivalent) with the given challenge
+   * and return the raw signature bytes from the assertion response.
+   */
+  requestAssertion(input: {
+    identityId: string;
+    keyId: string;
+    challenge: Uint8Array;
+  }): Promise<{ signature: Uint8Array }>;
+  now?: () => Date;
+  nonce?: () => string;
+}
+
 export type MutationAuthorizationInput = MutationAuthorization | MutationSigner;
 
 export interface ReadinessResponse {
@@ -266,6 +283,36 @@ export function createWebCryptoMutationSigner(
         encoded,
       );
       const signature = btoa(String.fromCharCode(...new Uint8Array(sigBytes)));
+
+      return { ...draft, signature };
+    },
+  };
+}
+
+export function createPasskeyMutationSigner(
+  input: PasskeyMutationSignerInput,
+): MutationSigner {
+  return {
+    async signMutation(request) {
+      const timestamp = input.now?.() ?? new Date();
+      const keyId = input.keyId ?? "root";
+      const draft: MutationAuthorizationDraft = {
+        issuer: input.identityId,
+        signatureKeyId: keyId,
+        method: request.method.toUpperCase(),
+        path: request.path,
+        bodyHash: hashBody(request.body),
+        timestamp: timestamp.toISOString(),
+        nonce: input.nonce?.() ?? randomNonce(),
+      };
+
+      const challenge = new TextEncoder().encode(JSON.stringify(draft));
+      const { signature: sigBytes } = await input.requestAssertion({
+        identityId: input.identityId,
+        keyId,
+        challenge,
+      });
+      const signature = btoa(String.fromCharCode(...sigBytes));
 
       return { ...draft, signature };
     },

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -11,6 +11,7 @@ export {
   recoverNamespace,
   reserveNamespace,
   createSignedRequest,
+  createPasskeyMutationSigner,
   createWebCryptoMutationSigner,
   getReadiness,
   getRevocationState,
@@ -37,6 +38,7 @@ export {
 export type {
   AuditEventsResponse,
   IdentityEventsResponse,
+  PasskeyMutationSignerInput,
   ReadinessResponse,
   RevocationStateResponse,
   StatusResponse,


### PR DESCRIPTION
## Summary

- **`PasskeyKeyCustodyProvider`** (`packages/protocol/src/custody.ts`) — `KeyCustodyProvider` that delegates all signing to a caller-supplied `requestAssertion` callback; no `exportPrivateKey` method
- **`HsmKeyCustodyProvider` interface + `KmsKeyCustodyAdapter` skeleton** — wires `kmsProvision`/`kmsSign`/`kmsDescribe` callbacks to the provider contract; raw keys never leave the HSM
- **`createPasskeyMutationSigner`** (`@athome/sdk`) — `MutationSigner` that calls a WebAuthn `requestAssertion` callback with the mutation draft as the challenge; exported from SDK index
- **`POST /identities/:id/recovery-methods`** — registers a recovery method (email/phone/key/passkey/custom) into the identity manifest; signed mutation required
- **`POST /identities/:id/recover`** — executes recovery ceremony: validates method exists, rotates root key, emits `identity.recovered` event; blocked in production via `requireProductionCustody()`
- **`registerRecoveryMethod` + `executeRecoveryCeremony`** on `IdentityRegistry` in `packages/protocol`
- **`recovery.method.registered` + `identity.recovered`** added to `RegistryEventType`
- **5 new hardening tests**: register recovery method, ceremony with key export, ceremony blocked in production (403), key omitted by default, duplicate method rejected
- **`examples/browser-passkey-signer.ts`** — browser demo connecting `navigator.credentials.get` to `createPasskeyMutationSigner`
- **`docs/specs/v0.3-production-key-custody.md`** — SDK helper table, HSM adapter contract, Recovery Ceremony API docs, updated Acceptance Criteria

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npx vitest run` passes (59 tests)
- [ ] `npm run lint` passes
- [ ] Hardening tests: recovery registration, ceremony execution, production block, default key omission, duplicate rejection all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)